### PR TITLE
Import Base.typemin/typemax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 ColorTypes 0.2
 FixedPointNumbers 0.1
+StatsBase

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -8,7 +8,7 @@ import Base: ==, +, -, *, /, .+, .-, .*, ./, ^, .^, <, ~
 import Base: abs, abs2, clamp, convert, copy, div, eps, isfinite, isinf,
     isnan, isless, length, mapreduce, norm, one, promote_array_type,
     promote_op, promote_rule, zero, trunc, floor, round, ceil, bswap,
-    mod, rem, atan2, hypot, max, min, varm, real, histrange
+    mod, rem, atan2, hypot, max, min, varm, real, histrange, typemin, typemax
 
 # The unaryOps
 import Base:      conj, sin, cos, tan, sinh, cosh, tanh,

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -2,7 +2,7 @@ __precompile__(true)
 
 module ColorVectorSpace
 
-using ColorTypes, FixedPointNumbers
+using ColorTypes, FixedPointNumbers, StatsBase
 
 import Base: ==, +, -, *, /, .+, .-, .*, ./, ^, .^, <, ~
 import Base: abs, abs2, clamp, convert, copy, div, eps, isfinite, isinf,
@@ -394,7 +394,7 @@ function minus!{T,N}(out, b::Colorant, A::AbstractArray{T,N})
 end
 
 #histrange for Gray type
-Base.histrange{T}(v::AbstractArray{Gray{T}}, n::Integer) = histrange(convert(Array{Float32}, map(gray, v)), n)
+StatsBase.histrange{T}(v::AbstractArray{Gray{T}}, n::Integer) = StatsBase.histrange(convert(Array{Float32}, map(gray, v)), n)
 
 # Promotions for reductions
 if VERSION < v"0.5.0-dev+3701"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,11 +87,11 @@ facts("Colortypes") do
         a = Gray{U8}[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
         @fact histrange(a,10)-->0.1:0.1:1   
 
-        @fact ColorVectorSpace.typemin(RGB)-->RGB(0,0,0)
-        @fact ColorVectorSpace.typemin(Gray)-->Gray(0)
-        @fact ColorVectorSpace.typemax(Gray)-->Gray(1)
-        @fact ColorVectorSpace.typemin(ARGB)-->ARGB(0,0,0,0)
-        @fact ColorVectorSpace.typemax(ARGB)-->ARGB(1,1,1,1)
+        @fact typemin(RGB)-->RGB(0,0,0)
+        @fact typemin(Gray)-->Gray(0)
+        @fact typemax(Gray)-->Gray(1)
+        @fact typemin(ARGB)-->ARGB(0,0,0,0)
+        @fact typemax(ARGB)-->ARGB(1,1,1,1)
     end
 
     context("Comparisons with Gray") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 module ColorVectorSpaceTests
 
-using FactCheck, Base.Test, ColorVectorSpace, ColorTypes, FixedPointNumbers, Compat
+using FactCheck, Base.Test, ColorVectorSpace, ColorTypes, FixedPointNumbers, Compat, StatsBase
 
 macro test_colortype_approx_eq(a, b)
     :(test_colortype_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
@@ -85,7 +85,7 @@ facts("Colortypes") do
         @fact zero(ColorTypes.Gray)-->0
         @fact one(ColorTypes.Gray)-->1
         a = Gray{U8}[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-        @fact histrange(a,10)-->0.1:0.1:1   
+        @fact StatsBase.histrange(a,10)-->0.1f0:0.1f0:1f0
 
         @fact typemin(RGB)-->RGB(0,0,0)
         @fact typemin(Gray)-->Gray(0)


### PR DESCRIPTION
This way it's not necessary to scope calls to `typemin` and `typemax`.