### PR TITLE
Implement nan(RGB{Float32}) etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,22 @@ facts("Colortypes") do
         end
     end
 
+    context("nan") do
+        function make_checked_nan{T}(::Type{T})
+            x = nan(T)
+            isa(x, T) && isnan(x)
+        end
+        for S in (Float32, Float64)
+            @fact make_checked_nan(S) --> true
+            @fact make_checked_nan(Gray{S}) --> true
+            @fact make_checked_nan(AGray{S}) --> true
+            @fact make_checked_nan(GrayA{S}) --> true
+            @fact make_checked_nan(RGB{S}) --> true
+            @fact make_checked_nan(ARGB{S}) --> true
+            @fact make_checked_nan(ARGB{S}) --> true
+        end
+    end
+
     context("Arithmetic with Gray") do
         cf = Gray{Float32}(0.1)
         ccmp = Gray{Float32}(0.2)


### PR DESCRIPTION
`nan` is much like `zero` and `one`. Julia used to have a `nan` function but it got deprecated for `convert(T, NaN)` instead. However, in general it shouldn't be possible to convert a real number to an `RGB`, so I think we need to (re)introduce the `nan` function here.