### PR TITLE
Add dotc, for taking the grayscale-normalized dot product across color channels

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+Colors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,10 +192,10 @@ facts("Colortypes") do
         @fact 2.*cf --> ccmp
         @fact cf.*2 --> ccmp
         @fact cf/2.0f0 --> RGB{Float32}(0.05,0.1,0.15)
-        @fact cu/2 --> RGB(cu.r/2,cu.g/2,cu.b/2)
+        @fact cu/2 --> roughly(RGB(cu.r/2,cu.g/2,cu.b/2))
         @fact cu/0.5f0 --> RGB(cu.r/0.5f0, cu.g/0.5f0, cu.b/0.5f0)
         @fact cf+cf --> ccmp
-        @fact cu * 1//2 --> roughly(RGB{Float64}(U8(0.1)/2, U8(0.2)/2, U8(0.3)/2))
+        @fact cu * 1//2 --> mapc(x->Float64(Rational(x)/2), cu)
         @test_colortype_approx_eq (cf*[0.8f0])[1] RGB{Float32}(0.8*0.1,0.8*0.2,0.8*0.3)
         @test_colortype_approx_eq ([0.8f0]*cf)[1] RGB{Float32}(0.8*0.1,0.8*0.2,0.8*0.3)
         @test_colortype_approx_eq (cf.*[0.8f0])[1] RGB{Float32}(0.8*0.1,0.8*0.2,0.8*0.3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 module ColorVectorSpaceTests
 
-using FactCheck, Base.Test, ColorVectorSpace, ColorTypes, FixedPointNumbers, Compat
+using FactCheck, Base.Test, ColorVectorSpace, Colors, FixedPointNumbers, Compat
 
 macro test_colortype_approx_eq(a, b)
     :(test_colortype_approx_eq($(esc(a)), $(esc(b)), $(string(a)), $(string(b))))
@@ -303,6 +303,16 @@ facts("Colortypes") do
         a = ARGB{Float64}(1.0, 1.0, 1.0, 0.99)
         @fact isapprox(a, b, rtol = 0.01) --> false
         @fact isapprox(a, b, rtol = 0.1) --> true
+    end
+
+    context("dotc") do
+        @fact dotc(0.2, 0.2) --> 0.2^2
+        @fact dotc(0.2, 0.3f0) --> 0.2*0.3f0
+        @fact dotc(U8(0.2), U8(0.3)) --> Float32(U8(0.2))*Float32(U8(0.3))
+        @fact dotc(Gray{U8}(0.2), Gray24(0.3)) --> Float32(U8(0.2))*Float32(U8(0.3))
+        xc, yc = RGB(0.2,0.2,0.2), RGB{U8}(0.3,0.3,0.3)
+        @fact dotc(xc, yc) --> roughly(dotc(convert(Gray, xc), convert(Gray, yc)), 1e-6)
+        @fact dotc(RGB(1,0,0), RGB(0,1,1)) --> 0
     end
 end
 


### PR DESCRIPTION
This implements the "dot product" for Gray & RGB colors. Gray is obviously straightforward; for RGB, it's a little more subtle because we want `x = RGB(g, g, g)` (which can be thought of as a grayscale color since all colorchannels are identical) to yield the same value for both `dotc(x, x)` and `y = Gray(x); dotc(y, y)`. As a consequence, we weight the color channels in the manner consistent with conversion to rec601 luma.
