### PR TITLE
Fix promote_op for division

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -460,8 +460,11 @@ end
 
 # To help type inference
 promote_array_type{T<:Real,C<:MathTypes}(F, ::Type{T}, ::Type{C}) = base_colorant_type(C){Base.promote_array_type(F, T, eltype(C))}
-promote_op{C<:MathTypes,T<:Real}(F, ::Type{C}, ::Type{T}) = typeof(F(zero(C), zero(T)))
-promote_op{C<:MathTypes,T<:Real}(F, ::Type{T}, ::Type{C}) = typeof(F(zero(T), zero(C)))
+if VERSION < v"0.5.0-dev+1016"
+    Base.Broadcast.type_div{C<:MathTypes,T<:Real}(::Type{C}, ::Type{T}) = typeof(one(C)/one(T))
+    Base.Broadcast.type_div{C<:MathTypes,T<:Real}(::Type{T}, ::Type{C}) = typeof(one(T)/one(C))
+    Base.Broadcast.type_div{C1<:MathTypes,C2<:MathTypes}(::Type{C1}, ::Type{C2}) = typeof(one(C1)/one(C2))
+end
 promote_rule{C1<:Colorant,C2<:Colorant}(::Type{C1}, ::Type{C2}) = color_rettype(C1,C2){promote_type(eltype(C1), eltype(C2))}
 promote_rule{T<:Real,C<:AbstractGray}(::Type{T}, ::Type{C}) = promote_type(T, eltype(C))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,12 @@ facts("Colortypes") do
 
         acu = Gray{U8}[cu]
         acf = Gray{Float32}[cf]
+        @fact @inferred(acu./trues(1)) --> acu
+        @fact typeof(acu./trues(1)) --> Vector{typeof(cu/true)}
+        @fact @inferred(ones(Int, 1)./acu) --> [1/cu]
+        @fact typeof(ones(Int, 1)./acu) --> Vector{typeof(1/cu)}
+        @fact @inferred(acu./acu) --> [1]
+        @fact typeof(acu./acu) --> Vector{typeof(cu/cu)}
         @fact typeof(acu+acf) --> Vector{Gray{Float32}}
         @fact typeof(acu-acf) --> Vector{Gray{Float32}}
         @fact typeof(acu.+acf) --> Vector{Gray{Float32}}


### PR DESCRIPTION
For types that can't handle Inf, this seems important when inlining is off. (Dependence on inlining is weird, but I didn't really try to track it down.)

With the test added here (but omitting the specialized `promote_op` method), when inlining is off you get this error:
```jl
      Expression: acu ./ trues(1) --> acu
      ArgumentError: FixedPointNumbers.UFixed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent Inf
       in throw_converterror(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Float32) at /home/tim/.julia/v0.5/FixedPointNumbers/src/FixedPointNumbers.jl:126
       in _convert(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Type{UInt8}, ::Float32) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:55
       in convert(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Float32) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:52
       in /(::FixedPointNumbers.UFixed{UInt8,8}, ::FixedPointNumbers.UFixed{UInt8,8}) at /home/tim/.julia/v0.5/FixedPointNumbers/src/ufixed.jl:101
       in /(::FixedPointNumbers.UFixed{UInt8,8}, ::Bool) at ./promotion.jl:193
       in /(::ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}}, ::Bool) at /home/tim/.julia/v0.5/ColorVectorSpace/src/ColorVectorSpace.jl:254
       in promote_op(::Base.#/, ::Type{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}}}, ::Type{Bool}) at /home/tim/.julia/v0.5/ColorVectorSpace/src/ColorVectorSpace.jl:463
       in promote_eltype_op(::Function, ::Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1}, ::BitArray{1}) at ./abstractarray.jl:1669
       in broadcast(::Function, ::Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1}, ::BitArray{1}) at ./broadcast.jl:230
       in ./(::Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1}, ::BitArray{1}) at ./broadcast.jl:302
       in (::ColorVectorSpaceTests.##87#473{Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1},ColorVectorSpaceTests.##86#472{Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1}}})() at /home/tim/.julia/v0.5/FactCheck/src/FactCheck.jl:272
       in do_fact(::ColorVectorSpaceTests.##87#473{Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1},ColorVectorSpaceTests.##86#472{Array{ColorTypes.Gray{FixedPointNumbers.UFixed{UInt8,8}},1}}}, ::Expr, ::Symbol, ::FactCheck.ResultMetadata) at /home/tim/.julia/v0.5/FactCheck/src/FactCheck.jl:334
       in macro expansion at /home/tim/.julia/v0.5/FactCheck/src/FactCheck.jl:272 [inlined]
       in (::ColorVectorSpaceTests.##25#411{ColorVectorSpaceTests.#test_colortype_approx_eq#390})() at /home/tim/.julia/v0.5/ColorVectorSpace/test/runtests.jl:80
       in context(::ColorVectorSpaceTests.##25#411{ColorVectorSpaceTests.#test_colortype_approx_eq#390}, ::String) at /home/tim/.julia/v0.5/FactCheck/src/FactCheck.jl:475
       in (::ColorVectorSpaceTests.##5#389)() at /home/tim/.julia/v0.5/ColorVectorSpace/test/runtests.jl:39
       in facts(::ColorVectorSpaceTests.##5#389, ::String) at /home/tim/.julia/v0.5/FactCheck/src/FactCheck.jl:449
       in include_from_node1(::String) at ./loading.jl:488
       in process_options(::Base.JLOptions) at ./client.jl:262
       in _start() at ./client.jl:318
```