### PR TITLE
Support +/- for mixtures of RGB and Gray

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.5
-ColorTypes 0.3.0
+Colors 0.7.1
+ColorTypes 0.3.3
 FixedPointNumbers 0.3.0
 StatsBase 0.8.2
 Compat 0.9.1

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -2,7 +2,7 @@ __precompile__(true)
 
 module ColorVectorSpace
 
-using ColorTypes, FixedPointNumbers, Compat
+using Colors, FixedPointNumbers, Compat
 import StatsBase: histrange
 
 import Base: ==, +, -, *, /, .+, .-, .*, ./, ^, .^, <, ~
@@ -335,6 +335,15 @@ dotc(x::AbstractGray, y::AbstractGray) = dotc(promote(x, y)...)
 
 float{T<:Gray}(::Type{T}) = typeof(float(zero(T)))
 
+# Mixed types
+if VERSION < v"0.6.0-dev.2009"
+    (+)(a::MathTypes, b::MathTypes) = (+)(promote(a, b)...)
+    (-)(a::MathTypes, b::MathTypes) = (-)(promote(a, b)...)
+else
+    (+)(a::MathTypes, b::MathTypes) = (+)(Base.promote_noncircular(a, b)...)
+    (-)(a::MathTypes, b::MathTypes) = (-)(Base.promote_noncircular(a, b)...)
+end
+
 # Arrays
 (+){CV<:AbstractGray}(A::AbstractArray{CV}, b::AbstractGray) = (.+)(A, b)
 (+){CV<:AbstractGray}(b::AbstractGray, A::AbstractArray{CV}) = (.+)(b, A)
@@ -449,7 +458,6 @@ histrange{T}(v::AbstractArray{Gray{T}}, n::Integer) = histrange(convert(Array{Fl
 
 # To help type inference
 promote_array_type{T<:Real,C<:MathTypes}(F, ::Type{T}, ::Type{C}) = base_colorant_type(C){Base.promote_array_type(F, T, eltype(C))}
-promote_rule{C1<:Colorant,C2<:Colorant}(::Type{C1}, ::Type{C2}) = color_rettype(C1,C2){promote_type(eltype(C1), eltype(C2))}
 promote_rule{T<:Real,C<:AbstractGray}(::Type{T}, ::Type{C}) = promote_type(T, eltype(C))
 
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 BaseTestNext
-Colors 0.7.0
 StatsBase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,11 @@ end
         @test isapprox(a, b, rtol = 0.1)
     end
 
+    @testset "Mixed-type arithmetic" begin
+        @test RGB(1,0,0) + Gray(0.2f0) == RGB{Float32}(1.2,0.2,0.2)
+        @test RGB(1,0,0) - Gray(0.2f0) == RGB{Float32}(0.8,-0.2,-0.2)
+    end
+
     @testset "dotc" begin
         @test dotc(0.2, 0.2) == 0.2^2
         @test dotc(0.2, 0.3f0) == 0.2*0.3f0


### PR DESCRIPTION
For good measure, to help with the move of `zero` and `one` in #68 I threw in a dependency on ColorTypes 0.3.3 (which was not tagged when that PR was submitted).
