### PR TITLE
add isfinite method for Bool-based grays

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -239,6 +239,7 @@ min(a::Number, b::AbstractGray) = min(promote(a,b)...)
 min(a::AbstractGray, b::Number) = min(promote(a,b)...)
 
 isfinite{T<:AbstractFloat}(c::AbstractGray{T}) = isfinite(gray(c))
+isfinite{T<:Bool}(c::AbstractGray{T}) = isfinite(gray(c))
 isfinite(c::TransparentGrayFloat) = isfinite(gray(c)) && isfinite(alpha(c))
 isnan{T<:AbstractFloat}(c::AbstractGray{T}) = isnan(gray(c))
 isnan(c::TransparentGrayFloat) = isnan(gray(c)) && isnan(alpha(c))


### PR DESCRIPTION
This fixes a problem mentioned in JuliaGraphics/ColorTypes#76.  Adds a new `isfinite` definition for `ColorTypes.Gray{Bool}` instances, which complements the existing definitions for float-based grays.