### PR TITLE
import middle from StatsBase

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -10,9 +10,8 @@ import Base: abs, abs2, clamp, convert, copy, div, eps, isfinite, isinf,
     promote_op, promote_rule, zero, trunc, floor, round, ceil, bswap,
     mod, rem, atan2, hypot, max, min, real, typemin, typemax
 import LinearAlgebra: norm
-import StatsBase: histrange, varm
+import StatsBase: histrange, varm, middle
 import SpecialFunctions: gamma, lgamma, lfact
-import Statistics: middle
 
 export nan
 


### PR DESCRIPTION
Otherwise I get
```julia
julia> using ColorVectorSpace
[ Info: Precompiling module ColorVectorSpace
ERROR: LoadError: ArgumentError: Package ColorVectorSpace does not have Statistics in its dependencies:
 - If you have ColorVectorSpace checked out for development and have
   added Statistics as a dependency but haven't updated your primary
   environment's manifest file, try `Pkg.resolve()`.
 - Otherwise you may need to report an issue with ColorVectorSpace.

Stacktrace:
 [1] require(::Module, ::Symbol) at ./loading.jl:862
 [2] include at ./boot.jl:317 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1075
 [4] include(::Module, ::String) at ./sysimg.jl:29
 [5] top-level scope at none:0
 [6] eval at ./boot.jl:319 [inlined]
 [7] eval(::Expr) at ./client.jl:394
 [8] top-level scope at ./none:3 [inlined]
 [9] top-level scope at ./<missing>:0
in expression starting at /home/dani/.julia/dev/ColorVectorSpace/src/ColorVectorSpace.jl:15
ERROR: Failed to precompile ColorVectorSpace to /home/dani/.julia/compiled/v0.7/ColorVectorSpace/7uC4.ji.
Stacktrace:
 [1] error at ./error.jl:33 [inlined]
 [2] compilecache(::Base.PkgId) at ./loading.jl:1205
 [3] _require(::Base.PkgId) at ./loading.jl:1007
 [4] require(::Base.PkgId) at ./loading.jl:879
 [5] require(::Module, ::Symbol) at ./loading.jl:874
```
on Julia 0.7-beta