### PR TITLE
Eliminate duplicate types already defined in ColorTypes.jl

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -32,9 +32,7 @@ import Base:      conj, sin, cos, tan, sinh, cosh, tanh,
 
 export dotc
 
-AbstractGray{T} = Color{T,1}
-TransparentRGB{C<:AbstractRGB,T}   = TransparentColor{C,T,4}
-TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
+# TODO: we get rid of these definitions or move them to ColorTypes.jl
 TransparentRGBFloat{C<:AbstractRGB,T<:AbstractFloat} = TransparentColor{C,T,4}
 TransparentGrayFloat{C<:AbstractGray,T<:AbstractFloat} = TransparentColor{C,T,2}
 TransparentRGBNormed{C<:AbstractRGB,T<:Normed} = TransparentColor{C,T,4}


### PR DESCRIPTION
Another instance of duplicate types.

Depends on https://github.com/JuliaGraphics/ColorTypes.jl/pull/111