### PR TITLE
Proposal : add rand and randn

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,5 @@ ColorTypes 0.7.4
 FixedPointNumbers 0.3.0
 StatsBase 0.8.2
 SpecialFunctions
+ImageCore
+Random

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,4 +5,3 @@ FixedPointNumbers 0.3.0
 StatsBase 0.8.2
 SpecialFunctions
 ImageCore
-Random

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -2,13 +2,14 @@ __precompile__(true)
 
 module ColorVectorSpace
 
-using Colors, FixedPointNumbers, SpecialFunctions
+using Colors, FixedPointNumbers, SpecialFunctions, Random, ImageCore
 
 import Base: ==, +, -, *, /, ^, <, ~
 import Base: abs, abs2, clamp, convert, copy, div, eps, isfinite, isinf,
     isnan, isless, length, mapreduce, oneunit,
     promote_op, promote_rule, zero, trunc, floor, round, ceil, bswap,
     mod, rem, atan, hypot, max, min, real, typemin, typemax
+import Base: rand, randn
 import LinearAlgebra: norm
 import StatsBase: histrange, varm
 import SpecialFunctions: gamma, lgamma, lfact
@@ -170,6 +171,9 @@ abs2(c::TransparentRGB) = (ret = abs2(color(c)); ret + convert(typeof(ret), alph
 norm(c::AbstractRGB) = sqrt(abs2(c))
 norm(c::TransparentRGB) = sqrt(abs2(c))
 
+rand(rng::Random.AbstractRNG, T::Type{<:AbstractRGB}, dims::Int...) = colorview(RGB,rand(rng, eltype(T), (3,dims...)))
+randn(rng::Random.AbstractRNG, T::Type{<:AbstractRGB}, dims::Int...) = colorview(RGB,randn(rng, eltype(T), (3,dims...)))
+
 oneunit(::Type{C}) where {C<:AbstractRGB}     = C(1,1,1)
 oneunit(::Type{C}) where {C<:TransparentRGB}  = C(1,1,1,1)
 
@@ -258,6 +262,9 @@ abs2(c::TransparentGrayNormed) = Float32(gray(c))^2 + Float32(alpha(c))^2
 atan(x::Gray, y::Gray) = atan(convert(Real, x), convert(Real, y))
 hypot(x::Gray, y::Gray) = hypot(convert(Real, x), convert(Real, y))
 norm(c::TransparentGray) = sqrt(abs2(c))
+
+rand(rng::Random.AbstractRNG, T::Type{<:AbstractGray}, dims::Int...) = colorview(Gray,rand(rng, eltype(T), dims))
+randn(rng::Random.AbstractRNG, T::Type{<:AbstractGray}, dims::Int...) = colorview(Gray,randn(rng, eltype(T), dims))
 
 (<)(g1::AbstractGray, g2::AbstractGray) = gray(g1) < gray(g2)
 (<)(c::AbstractGray, r::Real) = gray(c) < r


### PR DESCRIPTION
I need this to reimplement `imgaussiannoise` in [Images](https://github.com/JuliaImages/Images.jl/blob/f6145afef096540aca323a128d5d4b3ffe894542/src/algorithms.jl#L551-L556) for RGB and Gray images.

Ask:

* Do I need to implement `rand` and `randn` for `TransparentGray` and `TransparentRGB`?
* It's better/necessary to have `Normed` supported, but I'm not very clear about what should `randn(N0f8,1)` should behave -- this needs a PR in `FixedPointNumbers`