### PR TITLE
Add some precompiles

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module ColorVectorSpace
 
 using Colors, FixedPointNumbers, SpecialFunctions
@@ -310,6 +308,9 @@ typemax(::Type{T}) where {T<:ColorTypes.AbstractGray} = T(typemax(eltype(T)))
 
 typemin(::T) where {T<:ColorTypes.AbstractGray} = T(typemin(eltype(T)))
 typemax(::T) where {T<:ColorTypes.AbstractGray} = T(typemax(eltype(T)))
+
+include("precompile.jl")
+_precompile_()
 
 ## Deprecations
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,14 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
+    pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
+    cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
+    realtypes = (Float16, Float32, Float64, Int)     # types for mixed Normed/Real operations
+    for R in realtypes, T in eltypes, C in pctypes
+        precompile(Tuple{typeof(+),C{T},C{T}})
+        precompile(Tuple{typeof(-),C{T},C{T}})
+        precompile(Tuple{typeof(*),R,C{T}})
+        precompile(Tuple{typeof(*),C{T},R})
+        precompile(Tuple{typeof(/),C{T},R})
+    end
+end


### PR DESCRIPTION
This adds some precompile statements to reduce latency. Because the methods are simple to infer, the savings are modest, but combined with precompiles in other packages (FixedPointNumbers, ColorTypes, Colors) I'm getting latency reductions of ~30% for some common operations. So these seem worth having.