### PR TITLE
Fix test breakage from FixedPointNumbers & bump [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorVectorSpace"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -13,8 +13,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ColorTypes = "0.8"
-Colors = "0.9"
-FixedPointNumbers = "0.5, 0.6"
+Colors = "0.9, 0.10"
+FixedPointNumbers = "0.5, 0.6, 0.7"
 SpecialFunctions = "0.7, 0.8, 0.9"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32"
 julia = "1"

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -111,6 +111,12 @@ arith_colorant_type(::Type{AGray32}) = AGray
 arith_colorant_type(::Type{RGB24}) = RGB
 arith_colorant_type(::Type{ARGB32}) = ARGB
 
+higher_float_precision_native(::Type{Float64}) = Float64   # Float64 is the highest native precision
+higher_float_precision_native(::Type{Float32}) = Float64
+higher_float_precision_native(::Type{Float16}) = Float32
+higher_float_precision_native(::Type{T}) where T<:Real = T
+higher_float_precision_native(x::T) where T<:Real = convert(higher_float_precision_native(T), x)
+
 ## Math on Colors. These implementations encourage inlining and,
 ## for the case of Normed types, nearly halve the number of multiplications (for RGB)
 
@@ -131,7 +137,7 @@ function (*)(f::Normed, c::AbstractRGB{T}) where T<:Normed
     arith_colorant_type(c){multype(typeof(f),T)}(fs*reinterpret(red(c)), fs*reinterpret(green(c)), fs*reinterpret(blue(c)))
 end
 function (/)(c::AbstractRGB{T}, f::Real) where T<:Normed
-    fs = (one(f)/reinterpret(oneunit(T)))/f
+    fs = (higher_float_precision_native(one(f))/reinterpret(oneunit(T)))/f
     arith_colorant_type(c){divtype(typeof(f),T)}(fs*reinterpret(red(c)), fs*reinterpret(green(c)), fs*reinterpret(blue(c)))
 end
 function (/)(c::AbstractRGB{T}, f::Integer) where T<:Normed


### PR DESCRIPTION
Upper bounds, while sometimes annoying, have their uses: see the test failures in https://github.com/JuliaGraphics/ColorVectorSpace.jl/pull/112. This appears to have been a case of "two wrongs make a right," and once FixedPointNumbers computed using higher precision the test here was broken. This represents a simple fix.

Alternatively we could simply accept the difference and keep the old code; after all, the whole purpose of this package is to do "wrong" things very quickly :smile: (https://github.com/JuliaGraphics/ColorVectorSpace.jl#introduction).

CC @kimikage, @johnnychen94 