### PR TITLE
Bump compatibility for FPN/ColorTypes/Colors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorVectorSpace"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -12,9 +12,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-ColorTypes = "0.8, 0.9"
-Colors = "0.9, 0.10, 0.11"
-FixedPointNumbers = "0.6, 0.7"
+ColorTypes = "0.8, 0.9, 0.10"
+Colors = "0.9, 0.10, 0.11, 0.12"
+FixedPointNumbers = "0.6, 0.7, 0.8"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32"
 julia = "1"

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -259,7 +259,9 @@ norm(c::TransparentGray) = sqrt(abs2(c))
 (<)(g1::AbstractGray, g2::AbstractGray) = gray(g1) < gray(g2)
 (<)(c::AbstractGray, r::Real) = gray(c) < r
 (<)(r::Real, c::AbstractGray) = r < gray(c)
-isless(g1::AbstractGray, g2::AbstractGray) = isless(gray(g1), gray(g2))
+if !hasmethod(isless, Tuple{AbstractGray,AbstractGray})  # this was moved to ColorTypes 0.10
+    isless(g1::AbstractGray, g2::AbstractGray) = isless(gray(g1), gray(g2))
+end
 isless(c::AbstractGray, r::Real) = isless(gray(c), r)
 isless(r::Real, c::AbstractGray) = isless(r, gray(c))
 


### PR DESCRIPTION
This is a minimal update that gets this working with the latest versions of FixedPointNumbers, ColorTypes, and Colors. I've checked that tests pass without warnings on both ColorTypes 0.9 and ColorTypes 0.10.

Closes #122 
Closes #127
Closes #128 