### PR TITLE
Add `complement` migrated from Images.jl

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -27,7 +27,7 @@ import SpecialFunctions: gamma, lgamma, lfact
 using Statistics
 import Statistics: middle, _mean_promote
 
-export RGBRGB, nan, dotc, dot, ⋅, hadamard, ⊙, tensor, ⊗, norm, varmult
+export RGBRGB, complement, nan, dotc, dot, ⋅, hadamard, ⊙, tensor, ⊗, norm, varmult
 
 MathTypes{T,C} = Union{AbstractRGB{T},TransparentRGB{C,T},AbstractGray{T},TransparentGray{C,T}}
 
@@ -224,6 +224,16 @@ const unaryOps = (:~, :conj, :abs,
 for op in unaryOps
     @eval ($op)(c::AbstractGray) = Gray($op(gray(c)))
 end
+
+"""
+    y = complement(x)
+
+Take the complement `1-x` of `x`.  If `x` is a color with an alpha channel,
+the alpha channel is left untouched. Don't forget to add a dot when `x` is
+an array: `complement.(x)`
+"""
+complement(x::Union{Number,Colorant}) = oneunit(x)-x
+complement(x::TransparentColor) = typeof(x)(complement(color(x)), alpha(x))
 
 middle(c::AbstractGray) = arith_colorant_type(c)(middle(gray(c)))
 middle(x::C, y::C) where {C<:AbstractGray} = arith_colorant_type(C)(middle(gray(x), gray(y)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,6 +479,20 @@ ColorTypes.blue(c::RatRGB)  = c.b
         @test cf ⋅ cf   === (Float64(red(cf))^2 + Float64(green(cf))^2 + Float64(blue(cf))^2)/3
     end
 
+    @testset "Complement" begin
+        @test complement(Gray(0.2)) === Gray(0.8)
+        @test complement(AGray(0.2f0, 0.7f0)) === AGray(0.8f0, 0.7f0)
+        @test complement(GrayA{N0f8}(0.2, 0.7)) === GrayA{N0f8}(0.8, 0.7)
+        @test_broken complement(Gray24(0.2)) === Gray24(0.8)
+        @test_broken complement(AGray32(0.2, 0.7)) === AGray32(0.8, 0.7)
+
+        @test complement(RGB(0, 0.3, 1)) === RGB(1, 0.7, 0)
+        @test complement(ARGB(0, 0.3f0, 1, 0.7f0)) === ARGB(1, 0.7f0, 0, 0.7f0)
+        @test complement(RGBA{N0f8}(0, 0.6, 1, 0.7)) === RGBA{N0f8}(1, 0.4, 0.0, 0.7)
+        @test complement(RGB24(0, 0.6, 1)) === RGB24(1, 0.4, 0.0)
+        @test complement(ARGB32(0, 0.6, 1, 0.7)) === ARGB32(1, 0.4, 0.0, 0.7)
+    end
+
     @testset "dotc" begin
         @test dotc(0.2, 0.2) == 0.2^2
         @test dotc(Int8(3), Int16(6)) === 18


### PR DESCRIPTION
This is the part of PR #125 about `complement`. (cf. https://github.com/JuliaImages/Images.jl/issues/698, https://github.com/JuliaImages/Images.jl/pull/879)

The differences from the original are as follows:
- This exports `complement` (as suggested in https://github.com/JuliaGraphics/ColorVectorSpace.jl/pull/125#discussion_r389335911).
- This drops the deprecation for array input.
  - It is the responsibility of Images.jl.
- This modifies the test.

Images.jl does not yet support ColorVectorSpace v0.9, so it is possible to include this in v0.9, but I don't think that would be a good idea.

Also, `oneunit(::AbstractGray)` has been missing. :confused: This may be fixed in ColorTypes v0.11.

cc: @wizofe