### PR TITLE
[WIP] Bump compatibility for ColorTypes v0.12

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -40,13 +40,16 @@ jobs:
         env:
           cache-name: cache-artifacts
         with:
-          path: ~/.julia/artifacts 
+          path: ~/.julia/artifacts
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-
+      - name: "add ColorTypes#master"
+        shell: bash
+        run: |
+          julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(name="ColorTypes", rev="master")); Pkg.instantiate()'
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 
 [compat]
-ColorTypes = "0.10, 0.11"
+ColorTypes = "0.11, 0.12"
 FixedPointNumbers = "0.8.2"
 SpecialFunctions = "0.8, 0.9, 0.10, 1"
 TensorCore = "0.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,15 +81,15 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         for x in (0.5, 0.5f0, NaN, NaN32, N0f8(0.5))
             @test @inferred(convert(Gray{typeof(x)}, x))  === @inferred(convert(Gray, x))  === Gray(x)
             @test @inferred(convert(RGB{typeof(x)}, x))   === @inferred(convert(RGB, x))   === RGB(x, x, x)
-            # These should be fixed by a future release of ColorTypes
-            @test_broken @inferred(convert(AGray{typeof(x)}, x)) === @inferred(convert(AGray, x)) === AGray(x, 1)
-            @test_broken @inferred(convert(ARGB{typeof(x)}, x))  === @inferred(convert(ARGB, x))  === ARGB(x, x, x, 1)
-            @test_broken @inferred(convert(GrayA{typeof(x)}, x)) === @inferred(convert(GrayA, x)) === GrayA(x, 1)
-            @test_broken @inferred(convert(RGBA{typeof(x)}, x))  === @inferred(convert(RGBA, x))  === RGBA(x, x, x, 1)
+            @test @inferred(convert(AGray{typeof(x)}, x)) === @inferred(convert(AGray, x)) === AGray(x, 1)
+            @test @inferred(convert(ARGB{typeof(x)}, x))  === @inferred(convert(ARGB, x))  === ARGB(x, x, x, 1)
+            @test @inferred(convert(GrayA{typeof(x)}, x)) === @inferred(convert(GrayA, x)) === GrayA(x, 1)
+            @test @inferred(convert(RGBA{typeof(x)}, x))  === @inferred(convert(RGBA, x))  === RGBA(x, x, x, 1)
         end
     end
 
     @testset "nan" begin
+        # `nan` for `Colorant` is defined in ColorTypes. It should be exported by ColorVectorSpace
         function make_checked_nan(::Type{T}) where T
             x = nan(T)
             isa(x, T) && mapreducec(isnan, &, true, x)
@@ -103,10 +103,6 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
             @test make_checked_nan(ARGB{S})
             @test make_checked_nan(RGBA{S})
         end
-    end
-
-    @testset "traits" begin
-        @test floattype(Gray{N0f8}) === Gray{float(N0f8)}
     end
 
     @testset "_mul" begin


### PR DESCRIPTION
In ColorTypes v0.12, the definitions of `one` and `AbstractGray` have (will be) changed. Also, as of ColorTypes v0.11, some methods have been migrated from this package to ColorTypes.
For these reasons, this drops the compatibility with ColorTypes v0.11 and earlier.