### PR TITLE
update unit test configuration

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -17,7 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:
+          - os: windows-latest
+            julia-version: '1'
+            arch: x64
+          - os: macOS-latest
+            julia-version: '1'
+            arch: x64
+          - os: ubuntu-latest
+            julia-version: '1'
+            arch: x86
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* remove cron jobs so that Github Action doesn't automatically disable our unit test CI after 60 days of inactivity
* add one x86 test target
* only test windows and macOS target with Julia 1 to reduce CI credits