### PR TITLE
Fix the definition of MathTypes

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -29,7 +29,7 @@ import Statistics: middle # and `_mean_promote`
 
 export RGBRGB, complement, nan, dotc, dot, ⋅, hadamard, ⊙, tensor, ⊗, norm, varmult
 
-MathTypes{T,C} = Union{AbstractRGB{T},TransparentRGB{C,T},AbstractGray{T},TransparentGray{C,T}}
+MathTypes{T,C<:Union{AbstractGray{T},AbstractRGB{T}}} = Union{C,TransparentColor{C,T}}
 
 ## Version compatibility with ColorTypes
 ### TODO: Remove the definitons other than `one` when dropping ColorTypes v0.10 support

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,17 +57,22 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
     end
 
     @testset "MathTypes" begin
-        @test Gray{Float32} <: ColorVectorSpace.MathTypes
-        @test AGray{Float32} <: ColorVectorSpace.MathTypes
-        @test GrayA{Float32} <: ColorVectorSpace.MathTypes
-        @test RGB{Float32} <: ColorVectorSpace.MathTypes
-        @test RGBA{Float32} <: ColorVectorSpace.MathTypes
-        @test ARGB{Float32} <: ColorVectorSpace.MathTypes
+        @test Gray{Float32} <: ColorVectorSpace.MathTypes{Float32} <: ColorVectorSpace.MathTypes
+        @test AGray{Float32} <: ColorVectorSpace.MathTypes{Float32}
+        @test GrayA{Float32} <: ColorVectorSpace.MathTypes{Float32}
+        @test RGB{Float32} <: ColorVectorSpace.MathTypes{Float32}
+        @test RGBA{Float32} <: ColorVectorSpace.MathTypes{Float32}
+        @test ARGB{Float32} <: ColorVectorSpace.MathTypes{Float32}
         @test !(HSV{Float32} <: ColorVectorSpace.MathTypes)
         @test !(HSVA{Float32} <: ColorVectorSpace.MathTypes)
         @test !(AHSV{Float32} <: ColorVectorSpace.MathTypes)
+        @test !(HSV <: ColorVectorSpace.MathTypes)
+        @test !(HSVA <: ColorVectorSpace.MathTypes)
+        @test !(AHSV <: ColorVectorSpace.MathTypes)
         @test AbstractGray <: ColorVectorSpace.MathTypes
         @test AbstractRGB <: ColorVectorSpace.MathTypes
+        @test AbstractGray{Float32} <: ColorVectorSpace.MathTypes{Float32}
+        @test AbstractRGB{Float32} <: ColorVectorSpace.MathTypes{Float32}
         @test_broken TransparentGray <: ColorVectorSpace.MathTypes
         @test_broken TransparentRGB <: ColorVectorSpace.MathTypes
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,22 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         @test isempty(detect_ambiguities(ColorVectorSpace))
     end
 
+    @testset "MathTypes" begin
+        @test Gray{Float32} <: ColorVectorSpace.MathTypes
+        @test AGray{Float32} <: ColorVectorSpace.MathTypes
+        @test GrayA{Float32} <: ColorVectorSpace.MathTypes
+        @test RGB{Float32} <: ColorVectorSpace.MathTypes
+        @test RGBA{Float32} <: ColorVectorSpace.MathTypes
+        @test ARGB{Float32} <: ColorVectorSpace.MathTypes
+        @test !(HSV{Float32} <: ColorVectorSpace.MathTypes)
+        @test !(HSVA{Float32} <: ColorVectorSpace.MathTypes)
+        @test !(AHSV{Float32} <: ColorVectorSpace.MathTypes)
+        @test AbstractGray <: ColorVectorSpace.MathTypes
+        @test AbstractRGB <: ColorVectorSpace.MathTypes
+        @test_broken TransparentGray <: ColorVectorSpace.MathTypes
+        @test_broken TransparentRGB <: ColorVectorSpace.MathTypes
+    end
+
     @testset "convert" begin
         for x in (0.5, 0.5f0, NaN, NaN32, N0f8(0.5))
             @test @inferred(convert(Gray{typeof(x)}, x))  === @inferred(convert(Gray, x))  === Gray(x)


### PR DESCRIPTION
Somewhat disturbingly, while `HSV` was not a subtype of `MathTypes`,
`AHSV` was. This mostly fixes the definition.

For a really, really good type hierarchy, we'll have to redesign
ColorTypes to enforce `C<:Color{T,N}`, e.g.
```
abstract type TransparentColor{T,N,M,C<:Color{T,M}} end
```
and then somehow link `M` to `N-1`. We can do that for specific cases
(e.g., AbstractRGB) but probably not in general.