### PR TITLE
Support reductions with `Gray{Bool}`

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -193,12 +193,15 @@ _div(x, y) = (T = divtype(typeof(x), typeof(y)); _div(T(x), T(y)))
 
 ## Generic algorithms
 Base.add_sum(c1::MathTypes,c2::MathTypes) = mapc(Base.add_sum, c1, c2)
-Base.add_sum(c1::AbstractGray{Bool}, c2::AbstractGray{Bool}) = Gray(FixedPointNumbers.Treduce(gray(c1)) + FixedPointNumbers.Treduce(gray(c2)))
+Base.add_sum(c1::MathTypes{Bool}, c2::MathTypes{Bool}) = mapc((x1, x2) -> FixedPointNumbers.Treduce(x1) + FixedPointNumbers.Treduce(x2), c1, c2)
 Base.reduce_first(::typeof(Base.add_sum), c::MathTypes) = mapc(x->Base.reduce_first(Base.add_sum, x), c)
+Base.reduce_first(::typeof(Base.add_sum), c::MathTypes{Bool}) = mapc(x->Base.reduce_first(Base.add_sum, N0f8(x)), c)
 function Base.reduce_empty(::typeof(Base.add_sum), ::Type{T}) where {T<:MathTypes}
     z = Base.reduce_empty(Base.add_sum, eltype(T))
     return zero(base_colorant_type(T){typeof(z)})
 end
+Base.reduce_empty(::typeof(Base.add_sum), ::Type{T}) where {T<:MathTypes{Bool}} =
+    Base.reduce_empty(Base.add_sum, base_colorant_type(T){N0f8})
 
 
 ## Rounding & mod

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -193,6 +193,7 @@ _div(x, y) = (T = divtype(typeof(x), typeof(y)); _div(T(x), T(y)))
 
 ## Generic algorithms
 Base.add_sum(c1::MathTypes,c2::MathTypes) = mapc(Base.add_sum, c1, c2)
+Base.add_sum(c1::AbstractGray{Bool}, c2::AbstractGray{Bool}) = Gray(FixedPointNumbers.Treduce(gray(c1)) + FixedPointNumbers.Treduce(gray(c2)))
 Base.reduce_first(::typeof(Base.add_sum), c::MathTypes) = mapc(x->Base.reduce_first(Base.add_sum, x), c)
 function Base.reduce_empty(::typeof(Base.add_sum), ::Type{T}) where {T<:MathTypes}
     z = Base.reduce_empty(Base.add_sum, eltype(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,7 +212,13 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         @test sum(a[1:1]) == a[1]
         @test abs( varmult(*, a) - (a[1]-a[2])^2 / 2 ) <= 0.001
         ab = Gray[true, true]
-        @test sum(ab) == Gray(n8sum(true, true))
+        @test sum(ab) === Gray(n8sum(true, true))
+        @test prod(ab) === Gray(true)
+        ab = Gray[true]
+        @test sum(ab) === Gray(n8sum(true, false))
+        @test prod(ab) === Gray(true)
+        @test sum(Gray{Bool}[]) === Gray(n8sum(false, false))
+        @test prod(Gray{Bool}[]) === one(Gray{Bool})
 
         @test real(Gray{Float32}) <: Real
         @test zero(ColorTypes.Gray) == 0
@@ -429,10 +435,14 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         a = RGB{N0f8}[RGB(1,0,0), RGB(1,0.8,0)]
         @test sum(a) == RGB(2.0,0.8,0)
         @test sum(typeof(a)()) == RGB(0.0,0.0,0)
+        ab = [RGB(true, false, true), RGB(true, false, false)]
+        @test sum(ab) === RGB(n8sum(true, true), n8sum(false, false), n8sum(true, false))
+        ab = [RGB(true, false, true)]
+        @test sum(ab) === RGB(n8sum(true, false), n8sum(false, false), n8sum(true, false))
+
         @test isapprox(a, a)
         a = RGB{Float64}(1.0, 1.0, 0.9999999999999999)
         b = RGB{Float64}(1.0, 1.0, 1.0)
-
         @test isapprox(a, b)
         a = RGB{Float64}(1.0, 1.0, 0.99)
         @test !(isapprox(a, b, rtol = 0.01))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,6 +211,8 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         @test sum(a) == Gray(n8sum(0.8,0.7))
         @test sum(a[1:1]) == a[1]
         @test abs( varmult(*, a) - (a[1]-a[2])^2 / 2 ) <= 0.001
+        ab = Gray[true, true]
+        @test sum(ab) == Gray(n8sum(true, true))
 
         @test real(Gray{Float32}) <: Real
         @test zero(ColorTypes.Gray) == 0


### PR DESCRIPTION
Formerly, `sum(Gray[true, true])` triggered an error
```julia
ERROR: ArgumentError: 2 is an integer in the range 0-255, but integer inputs are encoded with the N0f8
  type, an 8-bit type representing 256 discrete values between 0 and 1.
  Consider dividing your input values by 255, for example: Gray{N0f8}(2/255)
  Or use `reinterpret(N0f8, x)` if `x` is a `UInt8`.
  See the READMEs for FixedPointNumbers and ColorTypes for more information.
```
