### PR TITLE
Transition to noisy depwarn for `abs2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorVectorSpace"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ We anticipate the following transition schedule:
 - Sept 21, 2021: release ColorVectorSpace 0.9.7 with both `abs2` and `Future.abs2`.
   `abs2` will have a "quiet" deprecation warning (visible with `--depwarn=yes`
   or when running `Pkg.test`)
-- Jan 1, 2022: make the deprecation warning "noisy" (cannot be turned off).
+- May 19, 2022: make the deprecation warning "noisy" (cannot be turned off).
   This is designed to catch user-level scripts that may need to update thresholds
   or other constants.
-- *Apr 1, 2022: transition `abs2` to the new definition
+- *July 1, 2022: transition `abs2` to the new definition
   and make `Future.abs2` give a "noisy" depwarn to revert to regular `abs2`.
-- *July 1, 2022: remove `Future.abs2`.
+- *Dec 1, 2022: remove `Future.abs2`.
 
 The two marked with `*` denote breaking releases.

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -31,6 +31,12 @@ export RGBRGB, complement, nan, dotc, dot, ⋅, hadamard, ⊙, tensor, ⊗, norm
 
 MathTypes{T,C<:Union{AbstractGray{T},AbstractRGB{T}}} = Union{C,TransparentColor{C,T}}
 
+if Base.VERSION >= v"1.5"
+    @inline _depwarn(msg, funcsym; force=false) = Base.depwarn(msg, funcsym; force=force)
+else
+    @inline _depwarn(msg, funcsym; force=false) = Base.depwarn(msg, funcsym)
+end
+
 ## Version compatibility with ColorTypes
 ### TODO: Remove the definitons other than `one` when dropping ColorTypes v0.10 support
 
@@ -487,7 +493,7 @@ Base.length(r::StepRange{<:AbstractGray})                = length(StepRange(gray
 
 Base.abs2(g::AbstractGray) = abs2(gray(g))
 function Base.abs2(c::AbstractRGB)
-    Base.depwarn("""
+    _depwarn("""
     The return value of `abs2` will change to ensure that `abs2(g::Gray) ≈ abs2(RGB(g::Gray))`.
     For `RGB` colors, this results in dividing the previous output by 3.
 


### PR DESCRIPTION
This is part of the plan for changing the value returned by `abs2`.
This stage is designed to catch user-level scripts which may not
run with `--depwarn=yes`.