### PR TITLE
Math operations with explicit types

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -221,7 +221,7 @@ end
 eps(::Type{Gray{T}}) where {T} = Gray(eps(T))
 
 for f in (:trunc, :floor, :round, :ceil)
-    @eval $f(::Type{T}, g::Gray) where {T<:Integer} = Gray{T}($f(T, gray(g)))
+    @eval $f(::Type{T}, g::Gray) where {T<:Integer} = $f(T, gray(g))
 end
 
 for f in (:mod, :rem, :mod1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,7 +300,13 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         for g in (Gray{N0f8}(0.4), Gray{N0f8}(0.6))
             for op in (:trunc, :floor, :round, :ceil)
                 v = @eval $op(Bool, gray($g))
-                @test @eval($op(Bool, $g)) === Gray(v)
+                @test @eval($op(Bool, $g)) === v
+            end
+        end
+        for g in (Gray(1.4), Gray(1.6))
+            for op in (:trunc, :floor, :round, :ceil)
+                v = @eval $op(Int, gray($g))
+                @test @eval($op(Int, $g)) === v
             end
         end
         for (g1, g2) in ((Gray(0.4), Gray(0.3)), (Gray(N0f8(0.4)), Gray(N0f8(0.3))))


### PR DESCRIPTION
When called with explicit type we should return a result of that type.

Discussion for this is in JuliaGraphics/ColorTypes.jl/issues/123.

This breaks existing behaviour as per #131 and #126.

For example, `floor(Int, Gray(x))` should return an Int and the result should be the same as `floor(Int, x)`, treating `Gray`s as numbers.