### PR TITLE
conditionally use `SpecialFunctions` through weak deps or `Requires`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,20 +6,25 @@ version = "0.9.9"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
+
+[weakdeps]
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
+[extensions]
+SpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ColorTypes = "0.10, 0.11"
 FixedPointNumbers = "0.8.2"
-SpecialFunctions = "0.8, 0.9, 0.10, 1, 2.0"
 TensorCore = "0.1"
 julia = "1"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "Test"]
+test = ["SpecialFunctions", "Colors", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.9.9"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 
@@ -18,6 +19,7 @@ SpecialFunctionsExt = "SpecialFunctions"
 [compat]
 ColorTypes = "0.10, 0.11"
 FixedPointNumbers = "0.8.2"
+Requires = "1"
 TensorCore = "0.1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,18 +10,19 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 
+[compat]
+ColorTypes = "0.10, 0.11"
+FixedPointNumbers = "0.8.2"
+Requires = "1"
+SpecialFunctions = "0.8, 0.9, 0.10, 1, 2.0"
+TensorCore = "0.1"
+julia = "1"
+
 [weakdeps]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [extensions]
 SpecialFunctionsExt = "SpecialFunctions"
-
-[compat]
-ColorTypes = "0.10, 0.11"
-FixedPointNumbers = "0.8.2"
-Requires = "1"
-TensorCore = "0.1"
-julia = "1"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/ext/SpecialFunctionsExt.jl
+++ b/ext/SpecialFunctionsExt.jl
@@ -1,0 +1,21 @@
+module SpecialFunctionsExt
+    import SpecialFunctions
+    import ColorVectorSpace
+    using ColorTypes
+
+    const UnaryOps = (
+        :gamma, :logfactorial, :erf, :erfc, :erfcx, :erfi, :dawson,
+        :airyai, :airyaiprime, :airybi, :airybiprime,
+        :besselj0, :besselj1, :bessely0, :bessely1,
+        :eta, :zeta, :digamma
+    )
+
+    for op in UnaryOps
+        @eval SpecialFunctions.$op(c::AbstractGray) = Gray(SpecialFunctions.$op(gray(c)))
+    end
+
+    function SpecialFunctions.logabsgamma(c::AbstractGray)
+        lagc, s = SpecialFunctions.logabsgamma(gray(c))
+        return Gray(lagc), s
+    end
+end

--- a/ext/SpecialFunctionsExt.jl
+++ b/ext/SpecialFunctionsExt.jl
@@ -1,7 +1,8 @@
 module SpecialFunctionsExt
-    import SpecialFunctions
     import ColorVectorSpace
     using ColorTypes
+
+    isdefined(Base, :get_extension) ? (import SpecialFunctions) : (import ..SpecialFunctions)
 
     const UnaryOps = (
         :gamma, :logfactorial, :erf, :erfc, :erfcx, :erfi, :dawson,

--- a/ext/SpecialFunctionsExt.jl
+++ b/ext/SpecialFunctionsExt.jl
@@ -4,14 +4,14 @@ module SpecialFunctionsExt
 
     isdefined(Base, :get_extension) ? (import SpecialFunctions) : (import ..SpecialFunctions)
 
-    const UnaryOps = (
+    const unaryops = (
         :gamma, :logfactorial, :erf, :erfc, :erfcx, :erfi, :dawson,
         :airyai, :airyaiprime, :airybi, :airybiprime,
         :besselj0, :besselj1, :bessely0, :bessely1,
         :eta, :zeta, :digamma
     )
 
-    for op in UnaryOps
+    for op in unaryops
         @eval SpecialFunctions.$op(c::AbstractGray) = Gray(SpecialFunctions.$op(gray(c)))
     end
 

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -11,7 +11,7 @@ import Base: abs, clamp, convert, copy, div, eps, float,
     isfinite, isinf, isnan, isless, length, mapreduce, oneunit,
     promote_op, promote_rule, zero, trunc, floor, round, ceil, bswap,
     mod, mod1, rem, atan, hypot, max, min, real, typemin, typemax
-# More unaryOps (mostly math functions)
+# More unaryops (mostly math functions)
 import Base:      conj, sin, cos, tan, sinh, cosh, tanh,
                   asin, acos, atan, asinh, acosh, atanh,
                   sec, csc, cot, asec, acsc, acot,
@@ -292,7 +292,7 @@ dotc(x::T, y::T) where {T<:AbstractRGB} = 0.200f0 * acc(red(x))*acc(red(y)) + 0.
 dotc(x::AbstractRGB, y::AbstractRGB) = dotc(promote(x, y)...)
 
 # Scalar Gray
-const UnaryOps = (:~, :conj, :abs,
+const unaryops = (:~, :conj, :abs,
                   :sin, :cos, :tan, :sinh, :cosh, :tanh,
                   :asin, :acos, :atan, :asinh, :acosh, :atanh,
                   :sec, :csc, :cot, :asec, :acsc, :acot,
@@ -303,7 +303,7 @@ const UnaryOps = (:~, :conj, :abs,
                   :log, :log2, :log10, :log1p, :exponent, :exp,
                   :exp2, :exp10, :expm1, :cbrt, :sqrt,
                   :significand, :frexp, :modf)
-for op in UnaryOps
+for op in unaryops
     @eval ($op)(c::AbstractGray) = Gray($op(gray(c)))
 end
 

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -1,6 +1,6 @@
 module ColorVectorSpace
 
-using ColorTypes, FixedPointNumbers, SpecialFunctions
+using ColorTypes, FixedPointNumbers
 using TensorCore
 import TensorCore: ⊙, ⊗
 
@@ -23,7 +23,6 @@ import Base:      conj, sin, cos, tan, sinh, cosh, tanh,
                   exp2, exp10, expm1, cbrt, sqrt,
                   significand, frexp, modf
 import LinearAlgebra: norm, ⋅, dot, promote_leaf_eltypes  # norm1, norm2, normInf
-import SpecialFunctions: gamma, logabsgamma, lfact
 using Statistics
 import Statistics: middle # and `_mean_promote`
 
@@ -293,7 +292,7 @@ dotc(x::T, y::T) where {T<:AbstractRGB} = 0.200f0 * acc(red(x))*acc(red(y)) + 0.
 dotc(x::AbstractRGB, y::AbstractRGB) = dotc(promote(x, y)...)
 
 # Scalar Gray
-const unaryOps = (:~, :conj, :abs,
+const UnaryOps = (:~, :conj, :abs,
                   :sin, :cos, :tan, :sinh, :cosh, :tanh,
                   :asin, :acos, :atan, :asinh, :acosh, :atanh,
                   :sec, :csc, :cot, :asec, :acsc, :acot,
@@ -303,20 +302,9 @@ const unaryOps = (:~, :conj, :abs,
                   :asind, :atand, :rad2deg, :deg2rad,
                   :log, :log2, :log10, :log1p, :exponent, :exp,
                   :exp2, :exp10, :expm1, :cbrt, :sqrt,
-                  :significand,
-                  :gamma, :lfact, :frexp, :modf,
-                  :(SpecialFunctions.erf), :(SpecialFunctions.erfc),
-                  :(SpecialFunctions.erfcx), :(SpecialFunctions.erfi), :(SpecialFunctions.dawson),
-                  :(SpecialFunctions.airyai),
-                  :(SpecialFunctions.airyaiprime), :(SpecialFunctions.airybi), :(SpecialFunctions.airybiprime),
-                  :(SpecialFunctions.besselj0), :(SpecialFunctions.besselj1), :(SpecialFunctions.bessely0), :(SpecialFunctions.bessely1),
-                  :(SpecialFunctions.eta), :(SpecialFunctions.zeta), :(SpecialFunctions.digamma))
-for op in unaryOps
+                  :significand, :frexp, :modf)
+for op in UnaryOps
     @eval ($op)(c::AbstractGray) = Gray($op(gray(c)))
-end
-function logabsgamma(c::AbstractGray)
-    lagc, s = logabsgamma(gray(c))
-    return Gray(lagc), s
 end
 
 middle(c::AbstractGray) = arith_colorant_type(c)(middle(gray(c)))
@@ -522,6 +510,8 @@ For more information about the transition, see ColorVectorSpace's README.
 """
 abs2(c::Union{Real,AbstractGray,AbstractRGB}) = c ⋅ c
 end
+
+isdefined(Base, :get_extension) || include("../ext/SpecialFunctionsExt.jl")
 
 function __init__()
     if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)

--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -511,7 +511,7 @@ For more information about the transition, see ColorVectorSpace's README.
 abs2(c::Union{Real,AbstractGray,AbstractRGB}) = c ⋅ c
 end
 
-isdefined(Base, :get_extension) || include("../ext/SpecialFunctionsExt.jl")
+isdefined(Base, :get_extension) || using Requires
 
 function __init__()
     if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)
@@ -538,6 +538,9 @@ function __init__()
                 end
             end
         end
+    end
+    @static if !isdefined(Base, :get_extension)
+        @require SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b" include("../ext/SpecialFunctionsExt.jl")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,9 +288,9 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
             for mod in (
                 ColorVectorSpace,
                 SFE,
-                (; UnaryOps = (:trunc, :floor, :round, :ceil, :eps, :bswap)),
+                (; unaryops = (:trunc, :floor, :round, :ceil, :eps, :bswap)),
             )
-                for op in mod.UnaryOps
+                for op in mod.unaryops
                     op ∈ (:frexp, :exponent, :modf, :logfactorial) && continue
                     op === :~ && eltype(g) === Float64 && continue
                     op === :significand && eltype(g) === N0f8 && continue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,9 +280,14 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         for g in (Gray(0.4), Gray{N0f8}(0.4))
             @test @inferred(zero(g)) === typeof(g)(0)
             @test @inferred(oneunit(g)) === typeof(g)(1)
-            for opgroup in (ColorVectorSpace.unaryOps, (:trunc, :floor, :round, :ceil, :eps, :bswap))
-                for op in opgroup
-                    op ∈ (:frexp, :exponent, :modf, :lfact) && continue
+            for mod in (
+                ColorVectorSpace,
+                Base.get_extension(ColorVectorSpace, :SpecialFunctionsExt),
+                (; UnaryOps = (:trunc, :floor, :round, :ceil, :eps, :bswap)),
+            )
+                mod === nothing && continue  # pre weak dependencies
+                for op in mod.UnaryOps
+                    op ∈ (:frexp, :exponent, :modf, :logfactorial) && continue
                     op === :~ && eltype(g) === Float64 && continue
                     op === :significand && eltype(g) === N0f8 && continue
                     try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,12 +280,16 @@ ColorTypes.comp2(c::RGBA32) = alpha(c)
         for g in (Gray(0.4), Gray{N0f8}(0.4))
             @test @inferred(zero(g)) === typeof(g)(0)
             @test @inferred(oneunit(g)) === typeof(g)(1)
+            SFE = if isdefined(Base, :get_extension)
+                Base.get_extension(ColorVectorSpace, :SpecialFunctionsExt)
+            else
+                ColorVectorSpace.SpecialFunctionsExt
+            end
             for mod in (
                 ColorVectorSpace,
-                Base.get_extension(ColorVectorSpace, :SpecialFunctionsExt),
+                SFE,
                 (; UnaryOps = (:trunc, :floor, :round, :ceil, :eps, :bswap)),
             )
-                mod === nothing && continue  # pre weak dependencies
                 for op in mod.UnaryOps
                     op ∈ (:frexp, :exponent, :modf, :logfactorial) && continue
                     op === :~ && eltype(g) === Float64 && continue


### PR DESCRIPTION
Fix https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/184.
Fix https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/182.
Fix last part of https://github.com/JuliaPlots/UnicodePlots.jl/issues/291.

This is a proposal to make all the `SpecialFunctions` related functions (which are clearly piracy) optional using weak dependencies on `julia` >= 1.9 and `Requires` on older releases.

This would be (slightly) breaking so I guess we should bump `ColorVectorSpace` to `0.10.0` if this PR is merged, since you'd have to use:
```julia
julia> using SpecialFunctions
julia> using ColorVectorSpace
```
to recover all the functionalities on current master.

Note that `lfact` is renamed to `logfactorial` since `lfact` was deprecated in `SpecialFunctions`.

I followed the guidelines in https://pkgdocs.julialang.org/dev/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions) and https://docs.julialang.org/en/v1.10-dev/manual/code-loading/#man-extensions.

This PR was written for `ColorSchemes`, and `pkg> test ColorSchemes` passes locally since `ColorSchemes` does not depend on the `SpecialFunctions` functionalities defined in `ColorVectorSpace`.

Latency improvements:
<details>

**PR**
```julia
julia> @time @time_imports using ColorVectorSpace
      1.0 ms  Statistics
     66.4 ms  FixedPointNumbers
    100.7 ms  ColorTypes
      0.4 ms  TensorCore
    319.3 ms  ColorVectorSpace
  0.613890 seconds (553.44 k allocations: 39.516 MiB, 17.56% gc time, 16.28% compilation time)
```

**master**
```julia
julia> @time @time_imports using ColorVectorSpace
      1.5 ms  Statistics
     85.7 ms  FixedPointNumbers
    124.7 ms  ColorTypes
      8.0 ms  IrrationalConstants
      0.2 ms  Compat
    105.7 ms  ChainRulesCore
      1.4 ms  DocStringExtensions
      0.4 ms  LogExpFunctions
      0.3 ms  OpenLibm_jll
     23.2 ms  Preferences
      0.3 ms  JLLWrappers
      7.0 ms  OpenSpecFun_jll 90.69% compilation time
     22.2 ms  SpecialFunctions
      0.3 ms  TensorCore
    203.7 ms  ColorVectorSpace
  0.642129 seconds (628.22 k allocations: 43.283 MiB, 5.46% compilation time)
```

</details>

Ping @timholy or @kimikage or @johnnychen94 for review (primary contributors to this repo).