### PR TITLE
[DoNotMerge] Add `[compat]` entry for Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ ColorTypes = "0.10, 0.11"
 FixedPointNumbers = "0.8.2"
 Requires = "1"
 SpecialFunctions = "0.8, 0.9, 0.10, 1, 2.0"
+Statistics = "<1.11.2"
 TensorCore = "0.1"
 julia = "1"
 


### PR DESCRIPTION
cf: https://github.com/JuliaMath/FixedPointNumbers.jl/pull/277#discussion_r1554726853

This can cause compatibility issues in downstream packages depending on Statistics (on Julia v1.6, etc.).