### PR TITLE
Add the CMY color model

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -30,7 +30,7 @@ isdefined(Base, :get_extension) || using Requires
 
 export RGBRGB, complement, nan, dotc, dot, ⋅, hadamard, ⊙, tensor, ⊗, norm, varmult, stdmult
 
-MathTypes{T,C<:Union{AbstractGray{T},AbstractRGB{T}}} = Union{C,TransparentColor{C,T}}
+MathTypes{T,C<:Union{AbstractGray{T},AbstractRGB{T},CMY}} = Union{C,TransparentColor{C,T}}
 
 ## Version compatibility with ColorTypes
 ### TODO: Remove the definitons other than `one` when dropping ColorTypes v0.10 support
@@ -161,6 +161,7 @@ channels(c::AbstractGray)    = (gray(c),)
 channels(c::TransparentGray) = (gray(c), alpha(c))
 channels(c::AbstractRGB)     = (red(c), green(c), blue(c))
 channels(c::TransparentRGB)  = (red(c), green(c), blue(c), alpha(c))
+channels(c::CMY)  = (cyan(c), magenta(c), yellow(c))
 
 if reinterpret(N0f16, 0xBADb)^2 === N0f16(float(reinterpret(N0f16, 0xBADb))^2)
     function _mul(x::N0f8, y::N0f8)
@@ -290,6 +291,14 @@ end
 # (rec601 luma), and normalizing
 dotc(x::T, y::T) where {T<:AbstractRGB} = 0.200f0 * acc(red(x))*acc(red(y)) + 0.771f0 * acc(green(x))*acc(green(y)) + 0.029f0 * acc(blue(x))*acc(blue(y))
 dotc(x::AbstractRGB, y::AbstractRGB) = dotc(promote(x, y)...)
+
+# CMY
+function (/)(c::CMY, f::AbstractFloat)
+    r = oneunit(divtype(eltype(c), typeof(f))) / f
+    _mapc(rettype(/, c, f), v -> v * r, c)
+end
+(+)(a::CMY, b::CMY) = _mapc(rettype(+, a, b), +, a, b)
+(-)(a::CMY, b::CMY) = _mapc(rettype(-, a, b), -, a, b)
 
 # Scalar Gray
 const unaryops = (:~, :conj, :abs,


### PR DESCRIPTION
This PR goes along with https://github.com/JuliaGraphics/ColorTypes.jl/pull/326 and https://github.com/JuliaGraphics/Colors.jl/pull/574 in an initiative to add the [CMY color model](https://en.wikipedia.org/wiki/CMYK_color_model#CMY).