### PR TITLE
[Documentation] Reattach the docstring for `Future.abs2`

### DIFF
--- a/src/ColorVectorSpace.jl
+++ b/src/ColorVectorSpace.jl
@@ -485,18 +485,17 @@ Base.abs2(c::Union{AbstractGray,AbstractRGB}) = c ⋅ c
 module Future
     using ..ColorTypes
     using ..ColorVectorSpace: ⋅
-    """
-        ColorVectorSpace.Future.abs2(c)
-    Return a scalar "squared magnitude" for color types. For RGB and gray, this is just the mean-square
-    channelwise intensity.
-    """
-
     if VERSION >= v"1.5"
         @inline _depwarn(msg, funcsym; force=false) = Base.depwarn(msg, funcsym; force=force)
     else
         @inline _depwarn(msg, funcsym; force=false) = Base.depwarn(msg, funcsym)
     end
 
+    """
+        ColorVectorSpace.Future.abs2(c)
+    Return a scalar "squared magnitude" for color types. For RGB and gray, this is just the mean-square
+    channelwise intensity.
+    """
     function abs2(c::Union{Real,AbstractGray,AbstractRGB})
         _depwarn("""
             The return value of `abs2` is now consistent with `ColorVectorSpace.Future.abs2`.


### PR DESCRIPTION
This is a trivial documentation issue. The docstring for `ColorVectorSpace.Future.abs2` is separated from the definition by a blank line and an intervening `if VERSION` block, so it is never attached.

```julia
julia> using ColorVectorSpace   # v0.11.0

julia> F = ColorVectorSpace.Future;

julia> haskey(Base.Docs.meta(F), Base.Docs.Binding(F, :abs2))
false
```

Moving the docstring down to `function abs2` restores it. Julia binds a string literal to the *immediately* following expression, and the manual notes that no blank lines or comments may intervene.
